### PR TITLE
Fix remote execution no DISPLAY variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `firefox_profiles` is object with profile names als fields. For each profile
           datareporting.healthreport.uploadEnabled: "false"
 
   roles:
-     - firefox
+     - basvandenbrink.firefox
 ```
 
 ## Credits

--- a/library/firefox_profile.py
+++ b/library/firefox_profile.py
@@ -81,7 +81,7 @@ class FirefoxProfiles:
             self.write()
 
     def create(self, name):
-        command = 'firefox -no-remote -CreateProfile %s' % name
+        command = 'firefox --headless -no-remote -CreateProfile %s' % name
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = p.communicate()
         if p.returncode != 0:


### PR DESCRIPTION
See commit message of ad4244ec48d53d46dc45e118324ec8f9d5426fc4 for the DISPLAY variable error.

Also fix the role name when installed using `ansible-galaxy`.

Tested on Ubuntu 20.04 (both control and target host).